### PR TITLE
Integrate Maxim observability

### DIFF
--- a/gpt_engineer/applications/cli/collect.py
+++ b/gpt_engineer/applications/cli/collect.py
@@ -32,6 +32,7 @@ from gpt_engineer.applications.cli.learning import (
 )
 from gpt_engineer.core.default.disk_memory import DiskMemory
 from gpt_engineer.core.prompt import Prompt
+from gpt_engineer.instrumentation import maxim_logger
 
 
 def send_learning(learning: Learning):
@@ -93,10 +94,19 @@ def collect_learnings(
     This function attempts to send the learning data to RudderStack. If the data size exceeds
     the maximum allowed size, it trims the data and retries sending it.
     """
+    trace = maxim_logger.start_trace("collect_learnings")
+    maxim_logger.log_feedback(
+        trace,
+        {
+            "score": int(bool(review.perfect)) if review.perfect is not None else 0,
+            "comment": review.comments,
+        },
+    )
     learnings = extract_learning(prompt, model, temperature, config, memory, review)
     try:
         send_learning(learnings)
-    except RuntimeError:
+    except RuntimeError as e:
+        maxim_logger.log_error(trace, str(e))
         # try to remove some parts of learning that might be too big
         # rudderstack max event size is 32kb
         max_size = 32 << 10  # 32KB in bytes
@@ -118,10 +128,13 @@ def collect_learnings(
         )
         try:
             send_learning(learnings)
-        except RuntimeError:
+        except RuntimeError as e:
+            maxim_logger.log_error(trace, str(e))
             print(
                 "Sending learnings crashed despite truncation. Progressing without saving learnings."
             )
+    finally:
+        maxim_logger.end_trace(trace)
 
 
 # def steps_file_hash():

--- a/gpt_engineer/applications/cli/main.py
+++ b/gpt_engineer/applications/cli/main.py
@@ -61,6 +61,7 @@ from gpt_engineer.core.files_dict import FilesDict
 from gpt_engineer.core.git import stage_uncommitted_to_git
 from gpt_engineer.core.preprompts_holder import PrepromptsHolder
 from gpt_engineer.core.prompt import Prompt
+from gpt_engineer.instrumentation import maxim_logger
 from gpt_engineer.tools.custom_steps import clarified_gen, lite_gen, self_heal
 
 app = typer.Typer(
@@ -454,6 +455,7 @@ def main(
         ), "Clarify and lite mode are not active for improve mode"
 
     load_env_if_needed()
+    maxim_logger.start_session()
 
     if llm_via_clipboard:
         ai = ClipboardAI()
@@ -555,6 +557,9 @@ def main(
         print("Total api cost: $ 0.0 since we are using local LLM.")
     else:
         print("Total tokens used: ", ai.token_usage_log.total_tokens())
+
+    maxim_logger.end_session()
+    maxim_logger.flush()
 
 
 if __name__ == "__main__":

--- a/gpt_engineer/core/ai.py
+++ b/gpt_engineer/core/ai.py
@@ -39,6 +39,7 @@ from langchain_anthropic import ChatAnthropic
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
 from gpt_engineer.core.token_usage import TokenUsageLog
+from gpt_engineer.instrumentation import maxim_logger
 
 # Type hint for a chat message
 Message = Union[AIMessage, HumanMessage, SystemMessage]
@@ -240,7 +241,16 @@ class AI:
         if not self.vision:
             messages = self._collapse_text_messages(messages)
 
-        response = self.backoff_inference(messages)
+        trace = maxim_logger.start_trace(step_name, AI.serialize_messages(messages))
+        try:
+            response = self.backoff_inference(messages)
+            maxim_logger.log_generation(trace, messages, response, self.model_name)
+            trace.set_output(response.content)
+        except Exception as e:
+            maxim_logger.log_error(trace, str(e))
+            raise
+        finally:
+            maxim_logger.end_trace(trace)
 
         self.token_usage_log.update_log(
             messages=messages, answer=response.content, step_name=step_name

--- a/gpt_engineer/core/default/disk_execution_env.py
+++ b/gpt_engineer/core/default/disk_execution_env.py
@@ -31,6 +31,7 @@ from typing import Optional, Tuple, Union
 from gpt_engineer.core.base_execution_env import BaseExecutionEnv
 from gpt_engineer.core.default.file_store import FileStore
 from gpt_engineer.core.files_dict import FilesDict
+from gpt_engineer.instrumentation import maxim_logger
 
 
 class DiskExecutionEnv(BaseExecutionEnv):
@@ -60,16 +61,27 @@ class DiskExecutionEnv(BaseExecutionEnv):
         return self.files.pull()
 
     def popen(self, command: str) -> subprocess.Popen:
-        p = subprocess.Popen(
-            command,
-            shell=True,
-            cwd=self.files.working_dir,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        return p
+        trace = maxim_logger.start_trace("popen", command)
+        try:
+            p = subprocess.Popen(
+                command,
+                shell=True,
+                cwd=self.files.working_dir,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            maxim_logger.log_tool_call(
+                trace,
+                "subprocess.popen",
+                {"cwd": str(self.files.working_dir)},
+                {"pid": p.pid},
+            )
+            return p
+        finally:
+            maxim_logger.end_trace(trace)
 
     def run(self, command: str, timeout: Optional[int] = None) -> Tuple[str, str, int]:
+        trace = maxim_logger.start_trace("run_command", command)
         start = time.time()
         print("\n--- Start of run ---")
         # while running, also print the stdout and stderr
@@ -107,5 +119,20 @@ class DiskExecutionEnv(BaseExecutionEnv):
             p.kill()
             print()
             print("--- Finished run ---\n")
+        except Exception as e:
+            maxim_logger.log_error(trace, str(e))
+            raise
+        finally:
+            maxim_logger.log_tool_call(
+                trace,
+                command,
+                {},
+                {
+                    "stdout": stdout_full,
+                    "stderr": stderr_full,
+                    "returncode": p.returncode,
+                },
+            )
+            maxim_logger.end_trace(trace)
 
         return stdout_full, stderr_full, p.returncode

--- a/gpt_engineer/core/default/disk_memory.py
+++ b/gpt_engineer/core/default/disk_memory.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterator, Optional, Union
 
 from gpt_engineer.core.base_memory import BaseMemory
+from gpt_engineer.instrumentation import maxim_logger
 from gpt_engineer.tools.supported_languages import SUPPORTED_LANGUAGES
 
 
@@ -99,19 +100,27 @@ class DiskMemory(BaseMemory):
         KeyError
             If the file corresponding to the key does not exist in the database.
         """
-        full_path = self.path / key
+        trace = maxim_logger.start_trace("disk_memory_getitem", key)
+        try:
+            full_path = self.path / key
 
-        if not full_path.is_file():
-            raise KeyError(f"File '{key}' could not be found in '{self.path}'")
+            if not full_path.is_file():
+                raise KeyError(f"File '{key}' could not be found in '{self.path}'")
 
-        if full_path.suffix in [".png", ".jpeg", ".jpg"]:
-            with full_path.open("rb") as image_file:
-                encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
-                mime_type = "image/png" if full_path.suffix == ".png" else "image/jpeg"
-                return f"data:{mime_type};base64,{encoded_string}"
-        else:
-            with full_path.open("r", encoding="utf-8") as f:
-                return f.read()
+            if full_path.suffix in [".png", ".jpeg", ".jpg"]:
+                with full_path.open("rb") as image_file:
+                    encoded_string = base64.b64encode(image_file.read()).decode("utf-8")
+                    mime_type = (
+                        "image/png" if full_path.suffix == ".png" else "image/jpeg"
+                    )
+                    result = f"data:{mime_type};base64,{encoded_string}"
+            else:
+                with full_path.open("r", encoding="utf-8") as f:
+                    result = f.read()
+            maxim_logger.log_retrieval(trace, "disk_get", key, result)
+            return result
+        finally:
+            maxim_logger.end_trace(trace)
 
     def get(self, key: str, default: Optional[Any] = None) -> Any:
         """
@@ -138,7 +147,10 @@ class DiskMemory(BaseMemory):
                 return DiskMemory(item_path)
             else:
                 return default
-        except:
+        except Exception as e:
+            trace = maxim_logger.start_trace("disk_memory_get_error", key)
+            maxim_logger.log_error(trace, str(e))
+            maxim_logger.end_trace(trace)
             return default
 
     def __setitem__(self, key: Union[str, Path], val: str) -> None:
@@ -170,6 +182,9 @@ class DiskMemory(BaseMemory):
         full_path.parent.mkdir(parents=True, exist_ok=True)
 
         full_path.write_text(val, encoding="utf-8")
+        trace = maxim_logger.start_trace("disk_memory_setitem", str(key))
+        maxim_logger.log_attachment(trace, {"path": str(full_path), "name": str(key)})
+        maxim_logger.end_trace(trace)
 
     def __delitem__(self, key: Union[str, Path]) -> None:
         """

--- a/gpt_engineer/instrumentation/__init__.py
+++ b/gpt_engineer/instrumentation/__init__.py
@@ -1,0 +1,37 @@
+"""Utilities for integrating Maxim observability."""
+
+from .maxim_logger import (
+    end_session,
+    end_span,
+    end_trace,
+    flush,
+    get_logger,
+    get_session,
+    log_attachment,
+    log_error,
+    log_feedback,
+    log_generation,
+    log_retrieval,
+    log_tool_call,
+    start_session,
+    start_span,
+    start_trace,
+)
+
+__all__ = [
+    "get_logger",
+    "start_session",
+    "get_session",
+    "end_session",
+    "start_trace",
+    "end_trace",
+    "start_span",
+    "end_span",
+    "log_generation",
+    "log_retrieval",
+    "log_tool_call",
+    "log_attachment",
+    "log_error",
+    "log_feedback",
+    "flush",
+]

--- a/gpt_engineer/instrumentation/maxim_logger.py
+++ b/gpt_engineer/instrumentation/maxim_logger.py
@@ -1,0 +1,136 @@
+import os
+import uuid
+
+from typing import Any, List
+
+from maxim import Logger
+from maxim.logger.components import (
+    ErrorConfig,
+    FeedbackDict,
+    FileAttachment,
+    GenerationRequestMessage,
+    RetrievalConfigDict,
+    SpanConfigDict,
+    ToolCallConfigDict,
+)
+from maxim.logger.components.generation import GenerationConfigDict
+from maxim.logger.logger import LoggerConfigDict
+
+_logger = None
+_session = None
+
+
+def get_logger() -> Logger:
+    global _logger
+    if _logger is None:
+        config: LoggerConfigDict = {
+            "id": os.getenv("MAXIM_LOGGER_ID", str(uuid.uuid4()))
+        }
+        api_key = os.getenv("MAXIM_API_KEY", "")
+        base_url = os.getenv("MAXIM_BASE_URL", "https://api.maxim.ai")
+        _logger = Logger(config, api_key=api_key, base_url=base_url)
+    return _logger
+
+
+def start_session() -> Any:
+    global _session
+    logger = get_logger()
+    _session = logger.session({"id": str(uuid.uuid4()), "name": "gpt-engineer"})
+    repo_id = os.getenv("MAXIM_REPO_ID")
+    if repo_id:
+        _session.add_tag("repo_id", repo_id)
+    return _session
+
+
+def get_session() -> Any:
+    if _session is None:
+        return start_session()
+    return _session
+
+
+def end_session():
+    if _session is not None:
+        _session.end()
+
+
+def start_trace(name: str, input_data: str = "") -> Any:
+    session = get_session()
+    trace = session.trace({"id": str(uuid.uuid4()), "name": name, "input": input_data})
+    trace.add_tag("step", name)
+    return trace
+
+
+def end_trace(trace: Any):
+    trace.end()
+
+
+def _msg_to_generation(message) -> GenerationRequestMessage:
+    role = getattr(message, "type", "user")
+    return {"role": role, "content": message.content}
+
+
+def log_generation(trace: Any, messages: List[Any], result: Any, model: str):
+    gen_conf: GenerationConfigDict = {
+        "id": str(uuid.uuid4()),
+        "provider": "openai",
+        "model": model,
+        "messages": [_msg_to_generation(m) for m in messages],
+    }
+    generation = trace.generation(gen_conf)
+    generation.result(result)
+
+
+def log_retrieval(trace: Any, name: str, query: str, docs: Any):
+    retr_conf: RetrievalConfigDict = {
+        "id": str(uuid.uuid4()),
+        "name": name,
+    }
+    retrieval = trace.retrieval(retr_conf)
+    retrieval.input(query)
+    retrieval.output(docs)
+
+
+def log_tool_call(trace: Any, name: str, metadata: dict, result: Any):
+    tool_conf: ToolCallConfigDict = {
+        "id": str(uuid.uuid4()),
+        "name": name,
+    }
+    tool = trace.tool_call(tool_conf)
+    tool.update(metadata)
+    tool.result(result)
+
+
+def log_attachment(trace: Any, data: dict):
+    attachment = FileAttachment(**data)
+    trace.add_attachment(attachment)
+
+
+def start_span(trace: Any, name: str, metadata: dict | None = None) -> Any:
+    span_conf: SpanConfigDict = {
+        "id": str(uuid.uuid4()),
+        "name": name,
+    }
+    span = trace.span(span_conf)
+    if metadata:
+        span.add_metadata(metadata)
+    return span
+
+
+def end_span(span: Any):
+    span.end()
+
+
+def log_error(trace: Any, message: str, code: str | None = None):
+    err_conf: ErrorConfig = {"message": message}
+    if code:
+        err_conf["code"] = code
+    trace.error(err_conf)
+
+
+def log_feedback(trace: Any, feedback: FeedbackDict):
+    trace.feedback(feedback)
+
+
+def flush():
+    logger = get_logger()
+    logger.flush()

--- a/gpt_engineer/instrumentation/maxim_logger.py
+++ b/gpt_engineer/instrumentation/maxim_logger.py
@@ -3,7 +3,7 @@ import uuid
 
 from typing import Any, List
 
-from maxim import Logger
+from maxim import Maxim
 from maxim.logger.components import (
     ErrorConfig,
     FeedbackDict,

--- a/gpt_engineer/instrumentation/maxim_logger.py
+++ b/gpt_engineer/instrumentation/maxim_logger.py
@@ -27,8 +27,7 @@ def get_logger() -> Logger:
             "id": os.getenv("MAXIM_LOGGER_ID", str(uuid.uuid4()))
         }
         api_key = os.getenv("MAXIM_API_KEY", "")
-        base_url = os.getenv("MAXIM_BASE_URL", None)
-        _logger = Logger(config, api_key=api_key, base_url=base_url)
+        _logger = Logger(config, api_key=api_key)
     return _logger
 
 

--- a/gpt_engineer/instrumentation/maxim_logger.py
+++ b/gpt_engineer/instrumentation/maxim_logger.py
@@ -27,7 +27,8 @@ def get_logger() -> Logger:
             "id": os.getenv("MAXIM_LOGGER_ID", str(uuid.uuid4()))
         }
         api_key = os.getenv("MAXIM_API_KEY", "")
-        _logger = Logger(config, api_key=api_key)
+        maxim = Maxim({"api_key":api_key})
+        _logger = maxim.logger(config)
     return _logger
 
 

--- a/gpt_engineer/instrumentation/maxim_logger.py
+++ b/gpt_engineer/instrumentation/maxim_logger.py
@@ -3,7 +3,7 @@ import uuid
 
 from typing import Any, List
 
-from maxim import Maxim
+from maxim import Maxim, Logger
 from maxim.logger.components import (
     ErrorConfig,
     FeedbackDict,

--- a/gpt_engineer/instrumentation/maxim_logger.py
+++ b/gpt_engineer/instrumentation/maxim_logger.py
@@ -27,7 +27,7 @@ def get_logger() -> Logger:
             "id": os.getenv("MAXIM_LOGGER_ID", str(uuid.uuid4()))
         }
         api_key = os.getenv("MAXIM_API_KEY", "")
-        base_url = os.getenv("MAXIM_BASE_URL", "https://api.maxim.ai")
+        base_url = os.getenv("MAXIM_BASE_URL", None)
         _logger = Logger(config, api_key=api_key, base_url=base_url)
     return _logger
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ langchain-anthropic = "^0.1.1"
 regex = "^2023.12.25"
 pillow = "^10.2.0"
 datasets = "^2.17.1"
+maxim-py = "^3.8.3"
 black = "23.3.0"
 langchain-community = "^0.2.0"
 

--- a/tests/instrumentation/test_maxim_logger.py
+++ b/tests/instrumentation/test_maxim_logger.py
@@ -1,0 +1,143 @@
+import types
+
+from gpt_engineer.applications.cli.collect import collect_learnings
+from gpt_engineer.applications.cli.learning import Review
+from gpt_engineer.core.default.disk_execution_env import DiskExecutionEnv
+from gpt_engineer.core.default.disk_memory import DiskMemory
+from gpt_engineer.core.prompt import Prompt
+from gpt_engineer.instrumentation import maxim_logger
+
+
+def test_start_session(monkeypatch):
+    events = {}
+
+    class DummySession:
+        def add_tag(self, k, v):
+            events["tag"] = (k, v)
+
+        def end(self):
+            events["end"] = True
+
+    class DummyLogger:
+        def session(self, conf):
+            events["conf"] = conf
+            return DummySession()
+
+    monkeypatch.setattr(maxim_logger, "get_logger", lambda: DummyLogger())
+    maxim_logger._session = None
+    maxim_logger.start_session()
+    assert events["conf"]["name"] == "gpt-engineer"
+
+
+def test_log_generation(monkeypatch):
+    events = {}
+
+    class DummyGen:
+        def result(self, out):
+            events["result"] = out
+
+    class DummyTrace:
+        def generation(self, conf):
+            events["conf"] = conf
+            return DummyGen()
+
+    maxim_logger.log_generation(
+        DummyTrace(), [types.SimpleNamespace(content="hi")], "out", "model"
+    )
+    assert events["conf"]["provider"] == "openai"
+    assert events["result"] == "out"
+
+
+def test_flush(monkeypatch):
+    events = {}
+
+    class DummyLogger:
+        def flush(self):
+            events["flush"] = True
+
+    monkeypatch.setattr(maxim_logger, "get_logger", lambda: DummyLogger())
+    maxim_logger.flush()
+    assert events["flush"]
+
+
+def test_disk_memory_getitem_logs(monkeypatch, tmp_path):
+    events = []
+
+    def start_trace(name, inp=""):
+        events.append(("start", name, inp))
+        return "t"
+
+    def log_retrieval(trace, name, query, docs):
+        events.append(("retrieval", query, docs))
+
+    def end_trace(trace):
+        events.append(("end", trace))
+
+    monkeypatch.setattr(maxim_logger, "start_trace", start_trace)
+    monkeypatch.setattr(maxim_logger, "log_retrieval", log_retrieval)
+    monkeypatch.setattr(maxim_logger, "end_trace", end_trace)
+
+    memory = DiskMemory(tmp_path)
+    (tmp_path / "a.txt").write_text("hello")
+    assert memory["a.txt"] == "hello"
+    assert events[0][0] == "start"
+    assert events[-1][0] == "end"
+
+
+def test_collect_learnings_logs_feedback(monkeypatch, tmp_path):
+    events = []
+
+    def start_trace(name, inp=""):
+        events.append(("start", name))
+        return "trace"
+
+    def log_feedback(trace, feedback):
+        events.append(("feedback", feedback))
+
+    def log_error(trace, msg):
+        events.append(("error", msg))
+
+    def end_trace(trace):
+        events.append(("end", trace))
+
+    monkeypatch.setattr(maxim_logger, "start_trace", start_trace)
+    monkeypatch.setattr(maxim_logger, "log_feedback", log_feedback)
+    monkeypatch.setattr(maxim_logger, "log_error", log_error)
+    monkeypatch.setattr(maxim_logger, "end_trace", end_trace)
+
+    memory = DiskMemory(tmp_path)
+    review = Review(ran=True, perfect=True, works=True, comments="ok", raw="y")
+    collect_learnings(Prompt("p"), "model", 0.1, ("fn",), memory, review)
+
+    assert events[0][0] == "start"
+    assert events[1][0] == "feedback"
+    assert events[-1][0] == "end"
+
+
+def test_execution_env_run_logs(monkeypatch, tmp_path):
+    events = []
+
+    def start_trace(name, inp=""):
+        events.append(("start", name))
+        return "trace"
+
+    def log_tool_call(trace, name, metadata, result):
+        events.append(("tool", name, result))
+
+    def log_error(trace, msg):
+        events.append(("error", msg))
+
+    def end_trace(trace):
+        events.append(("end", trace))
+
+    monkeypatch.setattr(maxim_logger, "start_trace", start_trace)
+    monkeypatch.setattr(maxim_logger, "log_tool_call", log_tool_call)
+    monkeypatch.setattr(maxim_logger, "log_error", log_error)
+    monkeypatch.setattr(maxim_logger, "end_trace", end_trace)
+
+    env = DiskExecutionEnv(tmp_path)
+    out, err, rc = env.run("echo hi")
+    assert "hi" in out
+    assert rc == 0
+    assert events[0][0] == "start"
+    assert events[-1][0] == "end"


### PR DESCRIPTION
## Summary
- add Maxim logger utilities for spans, retrieval, tools, attachments, feedback and errors
- update CLI to flush Maxim logs when run ends
- instrument DiskMemory operations for trace logging
- log model errors during generation
- expose observability helpers and add unit tests
- log user feedback and execution environment activity

## Testing
- `pytest -q` *(fails: ProxyError when tests attempt network access)*
- `python gpt_engineer/applications/cli/main.py --help`


------
https://chatgpt.com/codex/tasks/task_e_68494e7dbbd08324b5a353ac56a6939a